### PR TITLE
fix(github): move required to validations in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai-task.yml
+++ b/.github/ISSUE_TEMPLATE/ai-task.yml
@@ -8,6 +8,7 @@ body:
     attributes:
       label: Summary
       description: What needs to be done
+    validations:
       required: true
   - type: input
     id: area
@@ -19,4 +20,5 @@ body:
     attributes:
       label: Priority
       options: [high, medium, low]
+    validations:
       required: true


### PR DESCRIPTION
Move `required` attribute from `attributes` to `validations` section to comply with GitHub issue form template schema. Fixes validation errors for body[0] and body[2].

## Summary
Describe what this PR changes and why.

## Molecule Spec
Link to the filled template (commit or gist).

## ADR Link
ADR-XXXX: <Title or link>

## Contracts
- [ ] No changes
- [ ] New version added: <file>.v2.json
- [ ] Golden tests updated

## Safety
- [ ] Input validation
- [ ] Thresholds/e-stop (if applicable)
- [ ] Telemetry emitted

## Tests
- [ ] Unit tests
- [ ] Integration tests
- [ ] Contract validation passes

## Run Ledger (for experiments)
Path to ledger artifact and summary of results.
